### PR TITLE
add early returns for Maiden and Verzik rooms

### DIFF
--- a/src/main/java/gg/trevor/tobdamage/TobDamageCounterConfig.java
+++ b/src/main/java/gg/trevor/tobdamage/TobDamageCounterConfig.java
@@ -44,4 +44,14 @@ public interface TobDamageCounterConfig extends Config
 	default boolean showLeechOverlay() {
 		return true;
 	}
+
+	@ConfigItem(
+		keyName = "mvpDamage",
+		name = "Only count MVP damage",
+		description = "Only count damage that contributes to raid MVP"
+	)
+	default boolean showMVPDamage()
+	{
+		return false;
+	}
 }

--- a/src/main/java/gg/trevor/tobdamage/TobDamageCounterPlugin.java
+++ b/src/main/java/gg/trevor/tobdamage/TobDamageCounterPlugin.java
@@ -58,6 +58,9 @@ public class TobDamageCounterPlugin extends Plugin
 
 	private static final int VERZIK_HEAL_GRAPHIC = 1602;
 
+	private static final Set<Integer> maidenSpawns = ImmutableSet.of(NpcID.NYLOCAS_MATOMENOS, NpcID.BLOOD_SPAWN);
+	private static final Set<Integer> verzikIDs = ImmutableSet.of(NpcID.VERZIK_VITUR_8370, NpcID.VERZIK_VITUR_8372, NpcID.VERZIK_VITUR_8374);
+
 	@Inject
 	private Client client;
 
@@ -195,6 +198,19 @@ public class TobDamageCounterPlugin extends Plugin
 		if (currentRoom == null)
 		{
 			return;
+		}
+
+		if (config.showMVPDamage())
+		{
+			if (currentRoom == TobRooms.MAIDEN && maidenSpawns.contains(npc.getId()))
+			{
+				return;
+			}
+
+			if ((currentRoom == TobRooms.VERZIK_P1 || currentRoom == TobRooms.VERZIK_P2 || currentRoom == TobRooms.VERZIK_P3) && !verzikIDs.contains(npc.getId()))
+			{
+				return;
+			}
 		}
 
 		if (hitsplat.isMine())


### PR DESCRIPTION
This commit prevents damage tracking on the Nylo and Blood spawns in Maiden as well as Nylo (red/white/green/blue) and webs at Verzik. Damage done to these NPCs does not count towards MVP, thus by counting the damage done on them, we are not getting a true indication of damage performance in these rooms.

https://twitter.com/JagexAsh/status/1168229672062193664