### PR TITLE
Add minimap greenscreen option and dev run support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # Green Screen
 Adds a greenscreen, useful for content creators. Original author: I Yam Jeremy
+
+Current Maintainer: Ezra-Black

--- a/build.gradle
+++ b/build.gradle
@@ -5,12 +5,16 @@ plugins {
 repositories {
 	mavenLocal()
 	maven {
-		url = 'http://repo.runelite.net'
+		url = 'https://repo.runelite.net'
+		content {
+			includeGroupByRegex("net\\.runelite.*")
+		}
 	}
 	mavenCentral()
 }
 
 def runeLiteVersion = 'latest.release'
+def pluginMainClass = 'com.trevor.greenscreen.GreenScreenPluginTest'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
@@ -26,7 +30,13 @@ dependencies {
 group = 'com.trevor.greenscreen'
 version = '1.2'
 
-tasks.withType(JavaCompile) {
+tasks.withType(JavaCompile).configureEach {
 	options.encoding = 'UTF-8'
-//	options.release.set(11)
+}
+
+tasks.register('run', JavaExec) {
+	classpath = sourceSets.test.runtimeClasspath
+	mainClass = pluginMainClass
+	jvmArgs "-ea"
+	args "--developer-mode", "--debug"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,8 @@
-#Thu Dec 12 13:37:44 MST 2019
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.3-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionSha256Sum=682b4df7fe5accdca84a4d1ef6a3a6ab096b3efd5edf7de2bd8c758d95a93703
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-all.zip
+networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/run-developer.ps1
+++ b/run-developer.ps1
@@ -1,0 +1,29 @@
+# Run RuneLite in developer mode with Green Screen plugin.
+# Sets JAVA_HOME if missing so Gradle can run without system env config.
+
+$ErrorActionPreference = 'Stop'
+$ProjectRoot = $PSScriptRoot
+
+# Set JAVA_HOME if not already set
+if (-not $env:JAVA_HOME) {
+    $candidates = @(
+        "C:\Program Files\Eclipse Adoptium\jdk-17.0.18.8-hotspot",
+        "C:\Program Files\Java\jdk-17",
+        (Get-ChildItem "C:\Program Files\Eclipse Adoptium\jdk-*-hotspot" -ErrorAction SilentlyContinue | Sort-Object Name -Descending | Select-Object -First 1 -ExpandProperty FullName),
+        (Get-ChildItem "C:\Program Files\Java\jdk-*" -ErrorAction SilentlyContinue | Sort-Object Name -Descending | Select-Object -First 1 -ExpandProperty FullName)
+    )
+    foreach ($jdk in $candidates) {
+        if ($jdk -and (Test-Path (Join-Path $jdk "bin\java.exe"))) {
+            $env:JAVA_HOME = $jdk
+            Write-Host "Using JAVA_HOME: $env:JAVA_HOME"
+            break
+        }
+    }
+    if (-not $env:JAVA_HOME) {
+        Write-Error "Java not found. Install JDK 11+ (e.g. winget install EclipseAdoptium.Temurin.17.JDK) or set JAVA_HOME."
+        exit 1
+    }
+}
+
+Set-Location $ProjectRoot
+& "$ProjectRoot\gradlew.bat" run

--- a/src/main/java/com/trevor/greenscreen/GreenScreenConfig.java
+++ b/src/main/java/com/trevor/greenscreen/GreenScreenConfig.java
@@ -11,10 +11,21 @@ import java.awt.Color;
 public interface GreenScreenConfig extends Config
 {
 	@ConfigItem(
+		keyName = "mode",
+		name = "Greenscreen mode",
+		description = "Full game: green only on game world. Minimap only: green only on minimap. Both: green on game world and minimap.",
+		position = 0
+	)
+	default GreenscreenMode mode()
+	{
+		return GreenscreenMode.FULL_GAME;
+	}
+
+	@ConfigItem(
 		keyName = "color",
 		name = "Color",
 		description = "The color of the greenscreen",
-		position = 0
+		position = 1
 	)
 	default Color greenscreenColor()
 	{
@@ -25,7 +36,7 @@ public interface GreenScreenConfig extends Config
 			keyName = "toggleKey",
 			name= "Toggle Key",
 			description = "Key to press to toggle greenscreen",
-			position = 1
+			position = 2
 	)
 	default Keybind hotkey()
 	{
@@ -36,7 +47,7 @@ public interface GreenScreenConfig extends Config
 			keyName = "defaultState",
 			name = "Should Default On",
 			description = "What state should the greenscreen default to",
-			position = 2
+			position = 3
 	)
 	default boolean defaultState()
 	{

--- a/src/main/java/com/trevor/greenscreen/GreenScreenMinimapOverlay.java
+++ b/src/main/java/com/trevor/greenscreen/GreenScreenMinimapOverlay.java
@@ -1,0 +1,113 @@
+package com.trevor.greenscreen;
+
+import net.runelite.api.Client;
+import net.runelite.api.widgets.ComponentID;
+import net.runelite.api.widgets.Widget;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPosition;
+
+import javax.inject.Inject;
+import java.awt.*;
+import java.awt.geom.Area;
+import java.awt.geom.Ellipse2D;
+
+public class GreenScreenMinimapOverlay extends Overlay
+{
+	private static final int[] MINIMAP_COMPONENT_IDS = {
+		ComponentID.FIXED_VIEWPORT_MINIMAP_DRAW_AREA,
+		ComponentID.RESIZABLE_VIEWPORT_BOTTOM_LINE_MINIMAP_DRAW_AREA,
+		ComponentID.RESIZABLE_VIEWPORT_MINIMAP_DRAW_AREA
+	};
+
+	/** Component IDs for orbs/buttons around the minimap that must not be covered. */
+	private static final int[] MINIMAP_ORB_COMPONENT_IDS = {
+		ComponentID.MINIMAP_HEALTH_ORB,
+		ComponentID.MINIMAP_PRAYER_ORB,
+		ComponentID.MINIMAP_RUN_ORB,
+		ComponentID.MINIMAP_SPEC_ORB,
+		ComponentID.MINIMAP_QUICK_PRAYER_ORB,
+		ComponentID.MINIMAP_TOGGLE_RUN_ORB,
+		ComponentID.MINIMAP_XP_ORB,
+		ComponentID.MINIMAP_WORLDMAP_ORB,
+		ComponentID.MINIMAP_WIKI_BANNER_PARENT
+	};
+
+	private final Client client;
+	private final GreenScreenConfig config;
+	private final GreenScreenPlugin plugin;
+
+	@Inject
+	public GreenScreenMinimapOverlay(Client client, GreenScreenConfig config, GreenScreenPlugin plugin)
+	{
+		this.client = client;
+		this.config = config;
+		this.plugin = plugin;
+		setLayer(OverlayLayer.ABOVE_WIDGETS);
+		setPosition(OverlayPosition.DYNAMIC);
+	}
+
+	@Override
+	public Dimension render(Graphics2D g)
+	{
+		if (!plugin.isRenderGreenscreen())
+		{
+			return null;
+		}
+
+		GreenscreenMode mode = config.mode();
+		if (mode != GreenscreenMode.MINIMAP_ONLY && mode != GreenscreenMode.BOTH)
+		{
+			return null;
+		}
+
+		Widget minimap = getMinimapWidget();
+		if (minimap == null || minimap.isHidden())
+		{
+			return null;
+		}
+
+		Rectangle bounds = minimap.getBounds();
+		int centerX = bounds.x + bounds.width / 2;
+		int centerY = bounds.y + bounds.height / 2;
+		int radius = Math.min(bounds.width, bounds.height) / 2;
+
+		Area fill = new Area(new Ellipse2D.Double(
+			centerX - radius,
+			centerY - radius,
+			radius * 2,
+			radius * 2
+		));
+
+		for (int componentId : MINIMAP_ORB_COMPONENT_IDS)
+		{
+			Widget w = client.getWidget(componentId);
+			if (w != null && !w.isHidden())
+			{
+				Rectangle orbBounds = w.getBounds();
+				if (orbBounds != null && !orbBounds.isEmpty())
+				{
+					fill.subtract(new Area(orbBounds));
+				}
+			}
+		}
+
+		g.setColor(config.greenscreenColor());
+		g.fill(fill);
+
+		return null;
+	}
+
+	private Widget getMinimapWidget()
+	{
+		for (int componentId : MINIMAP_COMPONENT_IDS)
+		{
+			Widget w = client.getWidget(componentId);
+			if (w != null && !w.isHidden())
+			{
+				return w;
+			}
+		}
+		return null;
+	}
+}

--- a/src/main/java/com/trevor/greenscreen/GreenScreenOverlay.java
+++ b/src/main/java/com/trevor/greenscreen/GreenScreenOverlay.java
@@ -40,14 +40,27 @@ public class GreenScreenOverlay extends Overlay
 			return null;
 		}
 
+		GreenscreenMode mode = config.mode();
+		if (mode != GreenscreenMode.FULL_GAME && mode != GreenscreenMode.BOTH)
+		{
+			return null;
+		}
+
 		BufferedImage image = new BufferedImage(client.getCanvasWidth(), client.getCanvasHeight(), BufferedImage.TYPE_4BYTE_ABGR);
 		Graphics g = image.getGraphics();
 
 		g.setColor(config.greenscreenColor());
 		g.fillRect(0, 0, image.getWidth(), image.getHeight());
 
+		Player localPlayer = client.getLocalPlayer();
+		if (localPlayer == null || localPlayer.getModel() == null)
+		{
+			graphics.drawImage(image, 0, 0, null);
+			return null;
+		}
+
 		Polygon[] polygons = getPolygons();
-		Triangle[] triangles = getTriangles(client.getLocalPlayer().getModel());
+		Triangle[] triangles = getTriangles(localPlayer.getModel());
 
 		for (int i = 0; i < polygons.length; i++) {
 			Triangle t = triangles[i];

--- a/src/main/java/com/trevor/greenscreen/GreenScreenPlugin.java
+++ b/src/main/java/com/trevor/greenscreen/GreenScreenPlugin.java
@@ -1,7 +1,6 @@
 package com.trevor.greenscreen;
 
 import com.google.inject.Provides;
-import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.client.config.ConfigManager;
@@ -29,13 +28,20 @@ public class GreenScreenPlugin extends Plugin
 	private GreenScreenOverlay overlay;
 
 	@Inject
+	private GreenScreenMinimapOverlay minimapOverlay;
+
+	@Inject
 	private OverlayManager overlayManager;
 
 	@Inject
 	private KeyManager keyManager;
 
-	@Getter
 	private boolean renderGreenscreen;
+
+	public boolean isRenderGreenscreen()
+	{
+		return renderGreenscreen;
+	}
 
 	private final HotkeyListener hotkeyListener = new HotkeyListener(() -> config.hotkey())
 	{
@@ -50,6 +56,7 @@ public class GreenScreenPlugin extends Plugin
 	protected void startUp() throws Exception
 	{
 		overlayManager.add(overlay);
+		overlayManager.add(minimapOverlay);
 		renderGreenscreen = config.defaultState();
 		keyManager.registerKeyListener(hotkeyListener);
 	}
@@ -58,6 +65,7 @@ public class GreenScreenPlugin extends Plugin
 	protected void shutDown() throws Exception
 	{
 		overlayManager.remove(overlay);
+		overlayManager.remove(minimapOverlay);
 		keyManager.unregisterKeyListener(hotkeyListener);
 	}
 

--- a/src/main/java/com/trevor/greenscreen/GreenscreenMode.java
+++ b/src/main/java/com/trevor/greenscreen/GreenscreenMode.java
@@ -1,0 +1,21 @@
+package com.trevor.greenscreen;
+
+public enum GreenscreenMode
+{
+	FULL_GAME("Full game only"),
+	MINIMAP_ONLY("Minimap only"),
+	BOTH("Full game and minimap");
+
+	private final String name;
+
+	GreenscreenMode(String name)
+	{
+		this.name = name;
+	}
+
+	@Override
+	public String toString()
+	{
+		return name;
+	}
+}


### PR DESCRIPTION
- Added GreenscreenMode: Full game only, Minimap only, Both. This allows the user to choose which way he wants to run the greenscreen functionality. 
- Added GreenScreenMinimapOverlay (minimap chroma key, orbs excluded)
- GreenScreenOverlay only when mode is Full game or Both
- Single toggle key controls both overlays based on mode. 
- Add run task and run-developer.ps1 for dev mode (For testing and ease of future development)
- Upgrade Gradle wrapper to 8.10, use https repo (obious reasons)